### PR TITLE
Fix offline test execution by aligning dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2024"
 [dependencies]
 axum = "0.7"
 tokio = { version = "1", features = ["full"] }
-pulldown-cmark = "0.12"
-tower = { version = "0.4", features = ["util"] }
-tower-http = { version = "0.5", features = ["fs", "trace"] }
+pulldown-cmark = "0.13"
+tower = { version = "0.5", features = ["util"] }
+tower-http = { version = "0.6", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = { version = "1", features = ["derive"] }

--- a/tests/validation_test.rs
+++ b/tests/validation_test.rs
@@ -371,6 +371,11 @@ fn test_readme_markdown_links_are_well_formed() {
     // Every [ should have a corresponding ]( pattern for links
     let open_brackets = content.matches('[').count();
     let link_starts = content.matches("](").count();
+
+    assert!(
+        open_brackets >= link_starts,
+        "Each markdown link should have a matching opening bracket"
+    );
     
     assert!(
         link_starts > 0,
@@ -393,8 +398,6 @@ fn test_readme_markdown_links_are_well_formed() {
     }
     
     assert!(check_passed, "Markdown links should be properly formed with closing parentheses");
-}
-    );
 }
 
 #[test]
@@ -520,8 +523,8 @@ fn test_cargo_toml_tower_version() {
     
     // Check for tower version (the change in this PR)
     assert!(
-        content.contains("tower = { version = \"0.4\""),
-        "tower should be version 0.4"
+        content.contains("tower = { version = \"0.5\""),
+        "tower should be version 0.5"
     );
 }
 
@@ -532,8 +535,8 @@ fn test_cargo_toml_tower_http_version() {
     
     // Check for tower-http version (the change in this PR)
     assert!(
-        content.contains("tower-http = { version = \"0.5\""),
-        "tower-http should be version 0.5"
+        content.contains("tower-http = { version = \"0.6\""),
+        "tower-http should be version 0.6"
     );
 }
 


### PR DESCRIPTION
## Summary
- bump the pulldown-cmark, tower, and tower-http dependencies to the versions available in the cached registry
- update validation assertions to expect the new dependency versions and strengthen the README link check

## Testing
- `CARGO_NET_OFFLINE=true cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68fea042376c832eabdf8b55943d1ed1