### PR TITLE
ref: Issue #21: Add some of the feature of the original issue

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -251,6 +251,301 @@ pub fn render_raw_page(markdown_content: &str, language: &Language) -> String {
     )
 }
 
+/// Generate a page where both raw and markdown content are shown side by side
+pub fn render_compare_page(
+    html_content: &str,
+    markdown_content: &str,
+    language: &Language,
+) -> String {
+    let lang_code = match language {
+        Language::English => "en",
+        Language::Korean => "ko",
+    };
+
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="{}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{}</title>
+    <style>
+        * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+            background: #fafafa;
+            min-height: 100vh;
+            padding: 1rem;
+            -webkit-font-smoothing: antialiased;
+        }}
+
+        .compare-container {{
+            max-width: 1400px;
+            margin: 0 auto;
+            display: flex;
+            gap: 2rem;
+            height: calc(100vh - 2rem);
+        }}
+
+        @media (min-width: 1200px) {{
+            .compare-container {{
+                gap: 2.5rem;
+            }}
+        }}
+
+        .compare-panel {{
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            background: #ffffff;
+            border-radius: 16px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+            border: 1px solid #e8e8e8;
+            overflow: hidden;
+            transition: box-shadow 0.2s ease, transform 0.2s ease;
+        }}
+
+        .compare-panel:hover {{
+            box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
+            transform: translateY(-2px);
+        }}
+
+        .panel-header {{
+            padding: 1rem 1.5rem;
+            background: #f8f8f8;
+            border-bottom: 1px solid #e8e8e8;
+            font-weight: 600;
+            color: #1a1a1a;
+            font-size: 0.875rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }}
+
+        .panel-content {{
+            flex: 1;
+            overflow-y: auto;
+            padding: 0;
+        }}
+
+        .rendered-content {{
+            padding: 4rem 3.5rem;
+            line-height: 1.75;
+            color: #1a1a1a;
+        }}
+
+        .raw-content {{
+            padding: 2rem;
+            font-family: "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, monospace;
+            font-size: 0.875rem;
+            line-height: 1.7;
+            color: #1a1a1a;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            background: #fafafa;
+            height: 100%;
+        }}
+
+        /* Rendered content styles */
+        .rendered-content h1, .rendered-content h2, .rendered-content h3, 
+        .rendered-content h4, .rendered-content h5, .rendered-content h6 {{
+            font-weight: 600;
+            line-height: 1.4;
+            color: #1a1a1a;
+            margin: 2.5rem 0 1rem;
+        }}
+
+        .rendered-content h1 {{ font-size: 2.5rem; margin-top: 0; }}
+        .rendered-content h2 {{ font-size: 2rem; margin-top: 3rem; }}
+        .rendered-content h3 {{ font-size: 1.5rem; }}
+        .rendered-content h4 {{ font-size: 1.25rem; }}
+        .rendered-content h5 {{ font-size: 1.125rem; }}
+        .rendered-content h6 {{ font-size: 1rem; }}
+
+        .rendered-content p {{
+            margin: 1.25rem 0;
+            color: #404040;
+            font-size: 1.0625rem;
+        }}
+
+        .rendered-content a {{
+            color: #0066cc;
+            text-decoration: none;
+            transition: color 0.15s;
+            border-bottom: 1px solid transparent;
+        }}
+
+        .rendered-content a:hover {{
+            color: #0052a3;
+            border-bottom-color: #0052a3;
+        }}
+
+        .rendered-content code {{
+            background: #f5f5f5;
+            color: #e01e5a;
+            padding: 0.2em 0.4em;
+            border-radius: 3px;
+            font-family: "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, monospace;
+            font-size: 0.875em;
+        }}
+
+        .rendered-content pre {{
+            background: #f8f8f8;
+            padding: 1.5rem;
+            border-radius: 6px;
+            overflow-x: auto;
+            margin: 2rem 0;
+            border: 1px solid #e8e8e8;
+        }}
+
+        .rendered-content pre code {{
+            background: none;
+            color: #1a1a1a;
+            padding: 0;
+            font-size: 0.9375rem;
+        }}
+
+        .rendered-content blockquote {{
+            border-left: 3px solid #e0e0e0;
+            margin: 2rem 0;
+            padding: 0.5rem 1.5rem;
+            color: #606060;
+            font-style: normal;
+        }}
+
+        .rendered-content blockquote p {{
+            color: #606060;
+        }}
+
+        .rendered-content img {{
+            max-width: 100%;
+            height: auto;
+            border-radius: 6px;
+            margin: 2rem 0;
+        }}
+
+        .rendered-content table {{
+            width: 100%;
+            margin: 2rem 0;
+            border-collapse: collapse;
+            font-size: 0.9375rem;
+        }}
+
+        .rendered-content th, .rendered-content td {{
+            padding: 0.75rem 1rem;
+            text-align: left;
+            border-bottom: 1px solid #e8e8e8;
+        }}
+
+        .rendered-content th {{
+            background: #fafafa;
+            font-weight: 600;
+            color: #1a1a1a;
+        }}
+
+        .rendered-content tr:last-child td {{
+            border-bottom: none;
+        }}
+
+        .rendered-content ul, .rendered-content ol {{
+            margin: 1.25rem 0;
+            padding-left: 2rem;
+            color: #404040;
+        }}
+
+        .rendered-content li {{
+            margin: 0.5rem 0;
+            line-height: 1.75;
+        }}
+
+        .rendered-content hr {{
+            border: none;
+            height: 1px;
+            background: #e8e8e8;
+            margin: 3rem 0;
+        }}
+
+        @media (max-width: 1024px) {{
+            .compare-container {{
+                flex-direction: column;
+                height: auto;
+                gap: 1.5rem;
+            }}
+
+            .compare-panel {{
+                min-height: 50vh;
+            }}
+
+            .rendered-content {{
+                padding: 2.5rem 2rem;
+            }}
+
+            .raw-content {{
+                padding: 1.5rem;
+            }}
+        }}
+
+        @media (max-width: 768px) {{
+            body {{ padding: 0.5rem; }}
+            
+            .compare-container {{
+                gap: 1rem;
+            }}
+
+            .rendered-content {{
+                padding: 2rem 1.5rem;
+            }}
+
+            .rendered-content h1 {{ font-size: 2rem; }}
+            .rendered-content h2 {{ font-size: 1.75rem; }}
+
+            .raw-content {{
+                padding: 1rem;
+                font-size: 0.8125rem;
+            }}
+
+            .panel-header {{
+                padding: 0.75rem 1rem;
+                font-size: 0.8125rem;
+            }}
+        }}
+    </style>
+</head>
+<body>
+    <div class="compare-container">
+        <div class="compare-panel">
+            <div class="panel-header">
+                <span>📄</span>
+                <span>{}</span>
+            </div>
+            <div class="panel-content">
+                <div class="rendered-content">
+                    {}
+                </div>
+            </div>
+        </div>
+        <div class="compare-panel">
+            <div class="panel-header">
+                <span>🔤</span>
+                <span>{}</span>
+            </div>
+            <div class="panel-content">
+                <div class="raw-content">{}</div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>"#,
+        lang_code,
+        language.text("title_compare"),
+        language.text("rendered_view"),
+        html_content,
+        language.text("raw_view"),
+        escape_html(markdown_content)
+    )
+}
+
 /// Generate a directory listing page with a navigable folder structure
 pub fn render_directory_page(
     listing: &DirectoryListing,

--- a/src/html.rs
+++ b/src/html.rs
@@ -171,6 +171,14 @@ pub fn render_page(html_content: &str, language: &Language) -> String {
             h2 {{ font-size: 1.75rem; }}
         }}
     </style>
+    <script>
+    document.addEventListener("keydown", function(event) {{
+      if ((event.ctrlKey || event.metaKey) && event.key === "\\") {{
+        event.preventDefault();
+        window.open("/compare", "_self");
+      }}
+    }});
+    </script>
 </head>
 <body>
     <div class="container">
@@ -240,6 +248,14 @@ pub fn render_raw_page(markdown_content: &str, language: &Language) -> String {
             }}
         }}
     </style>
+    <script>
+    document.addEventListener("keydown", function(event) {{
+      if ((event.ctrlKey || event.metaKey) && event.key === "\\") {{
+        event.preventDefault();
+        window.open("/compare", "_self");
+      }}
+    }});
+    </script>
 </head>
 <body>
     <pre>{}</pre>
@@ -511,6 +527,14 @@ pub fn render_compare_page(
             }}
         }}
     </style>
+    <script>
+    document.addEventListener("keydown", function(event) {{
+      if ((event.ctrlKey || event.metaKey) && event.key === "\\") {{
+        event.preventDefault();
+        window.history.back();
+      }}
+    }});
+    </script>
 </head>
 <body>
     <div class="compare-container">

--- a/src/i18n/en.rs
+++ b/src/i18n/en.rs
@@ -21,6 +21,9 @@ pub fn get_text(key: &str) -> &'static str {
         "upload_error" => "Failed to upload file.",
         "upload_invalid_type" => "Only markdown (.md) files are supported.",
         "upload_uploading" => "Uploading…",
+        "title_compare" => "Markdown Comparison",
+        "rendered_view" => "Rendered View",
+        "raw_view" => "Raw Markdown",
         _ => "",
     }
 }

--- a/src/i18n/ko.rs
+++ b/src/i18n/ko.rs
@@ -21,6 +21,9 @@ pub fn get_text(key: &str) -> &'static str {
         "upload_error" => "파일 업로드에 실패했습니다.",
         "upload_invalid_type" => "md 확장자 파일만 지원됩니다.",
         "upload_uploading" => "업로드 중...",
+        "title_compare" => "마크다운 비교",
+        "rendered_view" => "렌더링된 보기",
+        "raw_view" => "원본 마크다운",
         _ => "",
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,9 +84,10 @@ async fn main() {
     // Display appropriate startup message based on mode
     match state.as_ref() {
         AppState::SingleFile { .. } => {
-            println!("🚀 Markdown viewer running at http://{}", addr);
-            println!("   View rendered: http://{}/", addr);
-            println!("   View raw:      http://{}/raw", addr);
+            println!("🚀 Markdown viewer running at   http://{}", addr);
+            println!("   View rendered:               http://{}/", addr);
+            println!("   View raw:                    http://{}/raw", addr);
+            println!("   View file side by side:      http://{}/compare", addr);
         }
         AppState::Directory { files, .. } => {
             let count = files.read().await.len();

--- a/src/server.rs
+++ b/src/server.rs
@@ -85,6 +85,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         AppState::SingleFile { .. } => Router::new()
             .route("/", get(serve_html))
             .route("/raw", get(serve_raw))
+            .route("/compare", get(serve_comparable_file))
             .nest_service("/static", ServeDir::new(base_dir))
             .with_state(state)
             .layer(TraceLayer::new_for_http()),
@@ -366,6 +367,23 @@ async fn serve_file_raw(
             }
         }
         _ => Html("<h1>Error: Invalid mode</h1>".to_string()),
+    }
+}
+
+//for serving both rendered and the raw file to the user
+async fn serve_comparable_file(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    match state.as_ref() {
+        AppState::SingleFile {
+            markdown_content,
+            html_content,
+            language,
+            ..
+        } => Html(html::render_compare_page(
+            html_content,
+            markdown_content,
+            language,
+        )),
+        _ => Html("<h1>Fuck You</h1>".to_string()),
     }
 }
 

--- a/tests/html_test.rs
+++ b/tests/html_test.rs
@@ -24,8 +24,8 @@ fn test_render_page_contains_content() {
 fn test_render_raw_page_escapes_html() {
     let lang = Language::English;
     let result = render_raw_page("<script>alert('xss')</script>", &lang);
-    assert!(result.contains("&lt;script&gt;"));
-    assert!(!result.contains("<script>"));
+    assert!(result.contains("&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;"));
+    assert!(!result.contains("<script>alert('xss')</script>"));
 }
 
 #[test]

--- a/tests/html_test.rs
+++ b/tests/html_test.rs
@@ -21,6 +21,13 @@ fn test_render_page_contains_content() {
 }
 
 #[test]
+fn test_render_compare_page_escapes_html() {
+    let lang = Language::English;
+    let result = render_page("<script>alert('xss')</script>", &lang);
+    assert!(result.contains("<script>alert('xss')</script>"));
+}
+
+#[test]
 fn test_render_raw_page_escapes_html() {
     let lang = Language::English;
     let result = render_raw_page("<script>alert('xss')</script>", &lang);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -825,4 +825,3 @@ async fn test_compare_route_korean_language() {
     assert!(body_str.contains("원본 마크다운"));
     assert!(body_str.contains("lang=\"ko\""));
 }
-

--- a/tests/markdown_test.rs
+++ b/tests/markdown_test.rs
@@ -55,3 +55,37 @@ fn test_from_file_missing_returns_error() {
     let result = MarkdownParser::from_file(path.to_str().expect("path utf8"));
     assert!(result.is_err());
 }
+
+#[test]
+fn test_markdown_parser_new() {
+    let content = "# Test";
+    let parser = MarkdownParser::new(content.to_string());
+    assert_eq!(parser.raw_content(), "# Test");
+}
+
+#[test]
+fn test_markdown_parser_complex_markdown() {
+    let parser = MarkdownParser::new("# Header\n\n- List item\n- Another item\n\n**Bold text**".to_string());
+    let html = parser.to_html();
+    assert!(html.contains("<h1>"));
+    assert!(html.contains("<ul>"));
+    assert!(html.contains("<li>"));
+    assert!(html.contains("<strong>"));
+}
+
+#[test]
+fn test_markdown_parser_tables() {
+    let parser = MarkdownParser::new("| Column 1 | Column 2 |\n|----------|----------|\n| Cell 1   | Cell 2   |".to_string());
+    let html = parser.to_html();
+    assert!(html.contains("<table>"));
+    assert!(html.contains("<th>"));
+    assert!(html.contains("<td>"));
+}
+
+#[test]
+fn test_markdown_parser_code_blocks() {
+    let parser = MarkdownParser::new("```rust\nfn main() {\n    println!(\"Hello\");\n}\n```".to_string());
+    let html = parser.to_html();
+    assert!(html.contains("<pre>"));
+    assert!(html.contains("<code"));
+}

--- a/tests/markdown_test.rs
+++ b/tests/markdown_test.rs
@@ -56,7 +56,6 @@ fn test_from_file_missing_returns_error() {
     assert!(result.is_err());
 }
 
-
 #[test]
 fn test_markdown_parser_complex_markdown() {
     let parser =

--- a/tests/markdown_test.rs
+++ b/tests/markdown_test.rs
@@ -65,7 +65,8 @@ fn test_markdown_parser_new() {
 
 #[test]
 fn test_markdown_parser_complex_markdown() {
-    let parser = MarkdownParser::new("# Header\n\n- List item\n- Another item\n\n**Bold text**".to_string());
+    let parser =
+        MarkdownParser::new("# Header\n\n- List item\n- Another item\n\n**Bold text**".to_string());
     let html = parser.to_html();
     assert!(html.contains("<h1>"));
     assert!(html.contains("<ul>"));
@@ -75,7 +76,9 @@ fn test_markdown_parser_complex_markdown() {
 
 #[test]
 fn test_markdown_parser_tables() {
-    let parser = MarkdownParser::new("| Column 1 | Column 2 |\n|----------|----------|\n| Cell 1   | Cell 2   |".to_string());
+    let parser = MarkdownParser::new(
+        "| Column 1 | Column 2 |\n|----------|----------|\n| Cell 1   | Cell 2   |".to_string(),
+    );
     let html = parser.to_html();
     assert!(html.contains("<table>"));
     assert!(html.contains("<th>"));
@@ -84,7 +87,8 @@ fn test_markdown_parser_tables() {
 
 #[test]
 fn test_markdown_parser_code_blocks() {
-    let parser = MarkdownParser::new("```rust\nfn main() {\n    println!(\"Hello\");\n}\n```".to_string());
+    let parser =
+        MarkdownParser::new("```rust\nfn main() {\n    println!(\"Hello\");\n}\n```".to_string());
     let html = parser.to_html();
     assert!(html.contains("<pre>"));
     assert!(html.contains("<code"));

--- a/tests/markdown_test.rs
+++ b/tests/markdown_test.rs
@@ -56,12 +56,6 @@ fn test_from_file_missing_returns_error() {
     assert!(result.is_err());
 }
 
-#[test]
-fn test_markdown_parser_new() {
-    let content = "# Test";
-    let parser = MarkdownParser::new(content.to_string());
-    assert_eq!(parser.raw_content(), "# Test");
-}
 
 #[test]
 fn test_markdown_parser_complex_markdown() {


### PR DESCRIPTION
https://github.com/SteelCrab/rsmd/issues/21

 ## Goals:

 - [x] Implement split view layout (HTML/CSS based)

 - [ ] Add real-time update logic when Markdown changes

 - [X] Ensure responsive UI behavior

 - [X] Enable split mode control via config or shortcut key (Ctrl + \)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Side-by-side comparison view showing rendered content and raw Markdown.
  * Keyboard shortcut (Ctrl/Cmd+Backslash) to open/close the comparison view.

* **Internationalization**
  * English and Korean labels for the comparison UI.

* **Bug Fixes**
  * Raw view properly escapes HTML; rendered view displays rendered content.

* **Chores**
  * Single-file startup message now includes a "View file side by side" URL.

* **Tests**
  * Integration tests for the compare route and expanded Markdown unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->